### PR TITLE
Add cprimozic.net technology blog

### DIFF
--- a/web/data/categories/technology/list.toml
+++ b/web/data/categories/technology/list.toml
@@ -278,3 +278,8 @@
     title = "Bryan Lee"
     url = "https://www.bryanleetc.com/"
     favicon = "https://www.bryanleetc.com/theme/img/favicon.ico"
+
+    [blogs.cprimozicnet]
+    title = "Casey Primozic"
+    url = "https://cprimozic.net/"
+    favicon = "https://cprimozic.b-cdn.net/favicon-32x32.png"


### PR DESCRIPTION
Adding my personal site and blog.

Lots of programming-related blog posts, and a recently added "notes" section with a variety of technical content form tutorials, bug resolutions, software reviews, etc.

TY for putting this project together - these are always such great ways to find new feeds to follow that are free from marketing and social media "optimization".