### PR TITLE
Add dbohdan.com

### DIFF
--- a/web/data/categories/personal/list.toml
+++ b/web/data/categories/personal/list.toml
@@ -275,3 +275,8 @@
     favicon = "https://maxbo.me/favicon.ico"
     updated = "2025-01-03T09:15:17+0000"
 
+    [blogs.dbohdan]
+    title = "D. Bohdan"
+    url = "https://dbohdan.com/"
+    favicon = "https://dbohdan.com/favicon.ico"
+    updated = "2025-01-04T10:24:37+0000"


### PR DESCRIPTION
This PR adds [my personal wiki](https://dbohdan.com/). It [has been called](https://web.archive.org/web/20201022004958/https://notes.campegg.com/digital-gardens/) a digital garden. I have a lot of pages about computers, but the subject is not limited to technology, so I have added it as "personal".